### PR TITLE
[issue # 18] detectionLog, favorite이 0개일 때 페이징 조회시 예외처리

### DIFF
--- a/src/main/java/pocketyacsa/server/medicine/service/DetectionLogService.java
+++ b/src/main/java/pocketyacsa/server/medicine/service/DetectionLogService.java
@@ -87,6 +87,9 @@ public class DetectionLogService {
     int totalSize = repository.countByMemberId(loginMember.getId());
     int totalPages = (int) Math.ceil((double) totalSize / pageSize);
 
+    if (totalSize == 0) {
+      throw new BadRequestException(DETECTION_LOG_NOT_EXIST.getErrorResponse());
+    }
     if (page < 1 || page > totalPages) {
       throw new BadRequestException(PAGE_OUT_OF_RANGE.getErrorResponse());
     }

--- a/src/main/java/pocketyacsa/server/medicine/service/FavoriteService.java
+++ b/src/main/java/pocketyacsa/server/medicine/service/FavoriteService.java
@@ -105,6 +105,9 @@ public class FavoriteService {
     int totalSize = repository.countByMemberId(loginMember.getId());
     int totalPages = (int) Math.ceil((double) totalSize / pageSize);
 
+    if (totalSize == 0) {
+      throw new BadRequestException(FAVORITE_NOT_EXIST.getErrorResponse());
+    }
     if (page < 1 || page > totalPages) {
       throw new BadRequestException(PAGE_OUT_OF_RANGE.getErrorResponse());
     }

--- a/src/test/java/pocketyacsa/server/medicine/service/DetectionLogServiceTest.java
+++ b/src/test/java/pocketyacsa/server/medicine/service/DetectionLogServiceTest.java
@@ -254,4 +254,13 @@ class DetectionLogServiceTest {
 
     assertThrows(BadRequestException.class, () -> detectionLogService.getDetectionLogsByPage(page));
   }
+  @Test
+  public void getDetectionLogsByPage_DataNotExist() {
+    int page = 1;
+
+    when(memberService.getLoginMember()).thenReturn(member);
+    when(detectionLogRepository.countByMemberId(member.getId())).thenReturn(0);
+
+    assertThrows(BadRequestException.class, () -> detectionLogService.getDetectionLogsByPage(page));
+  }
 }

--- a/src/test/java/pocketyacsa/server/medicine/service/FavoriteServiceTest.java
+++ b/src/test/java/pocketyacsa/server/medicine/service/FavoriteServiceTest.java
@@ -282,4 +282,14 @@ class FavoriteServiceTest {
 
     assertThrows(BadRequestException.class, () -> favoriteService.getFavoritesByPage(page));
   }
+
+  @Test
+  public void getFavoritesByPage_DataNotExist() {
+    int page = 1;
+
+    when(memberService.getLoginMember()).thenReturn(member);
+    when(favoriteRepository.countByMemberId(member.getId())).thenReturn(0);
+
+    assertThrows(BadRequestException.class, () -> favoriteService.getFavoritesByPage(page));
+  }
 }


### PR DESCRIPTION
## 변경사항
- detectionLog, favorite이 0개일 때 페이징 조회시 예외처리